### PR TITLE
Add PR auto assigner

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,16 @@
+name: Auto Assign
+on:
+  pull_request:
+    types: [ready_for_review]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - name: 'Auto-assign'
+      uses: pozil/auto-assign-issue@v1
+      with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: ssec-jhu/team
+          numOfAssignee: 1


### PR DESCRIPTION
This will trigger on ``pull_request:ready_for_review`` and will assign to ``ssec-jhu/team``whose settings will auto assign 1 member from that team in a round-robin fashion.

To use the team settings otherwise, just manually request a review from ``ssec-jhu/team``. The idea for the committed workflow is for when opening a draft PR and then bumping it to ready for review.

Note: if the PR gets converted back to a draft and then marked again for review the auto assigner will assign a new member so be mindful of this and manually re-assign the original.
However, I've checked the following team setting which should fix this:
> Only notify requested team members
If both a team and one or more of its members are requested for review, don't notify the entire team.

See https://github.com/pozil/auto-assign-issue