### PR TITLE
Make ssec-jhu/team default code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @ssec-jhu/team


### PR DESCRIPTION
This should also trigger the round robin auto assignment.

🤔 Might need to check how this works when requiring review from code owner and the auto-assigner removing the team from the review list.