### PR TITLE
Use google style docstrings (napoleon), optional book theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
 ]
 
 intersphinx_mapping = {
@@ -29,10 +31,22 @@ templates_path = ['_templates']
 
 # -- Options for HTML output
 
+# select theme from options below
 html_theme = 'sphinx_rtd_theme'
+#html_theme = 'sphinx_book_theme'
 html_static_path = ['../_static']
 html_css_files = ['../_static/custom.css']
 html_logo = '../_static/SSEC_logo_vert_white_lg_1184x661.png'
+html_title = f'{project} {release}'
+html_theme_options = {
+    'logo': {
+        'image_light': '../_static/SSEC_logo_horiz_blue_1152x263.png',
+        'image_dark': '../_static/SSEC_logo_vert_white_lg_1184x661.png',
+        'text': f'{html_title}',
+    },
+    'repository_url': 'https://github.com/ssec-jhu/base-template',
+    'use_repository_button': True,
+ }
 
 
 # -- Options for EPUB output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
 docs = [
     "sphinx",
     "sphinx_rtd_theme",
+    "sphinx_book_theme",
     "sphinx-automodapi",
     "sphinx-issues",
     "nbsphinx"

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,6 +2,7 @@
 
 sphinx==6.2.1
 sphinx_rtd_theme==1.3.0
+sphinx_book_theme==1.0.1
 sphinx-automodapi==0.15.0
 sphinx-issues==3.0.1
 nbsphinx==0.9.2


### PR DESCRIPTION
The google style docstrings provided by napoleon extension are easier to write and read than the traditional ones, so use this by default. A popular theme is the book theme which has some nice features, adding option for that which we could take as default if desired.


FYI, screenshots showing book theme and rtd theme:

**RTD**

![image](https://github.com/ssec-jhu/base-template/assets/19286003/d7f29a73-9ac0-43ec-9a2a-5e6729102ab2)

**Book**

![image](https://github.com/ssec-jhu/base-template/assets/19286003/21f94144-cb4f-45f0-8006-00eca0d5363f)

