### PR TITLE
CI with tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
           python3 -m pip install --upgrade pip
           pip3 install -r requirements/dev.txt
         shell: bash
-      - name: Lint with ruff
-        run: ruff .
+      - name: Lint
+        run: tox -e check-style
         shell: bash
 
   test:
@@ -60,9 +60,8 @@ jobs:
       shell: bash -l {0}
     - name: pip install package
       run: pip install .
-    - name: Test with pytest
-      run: |
-        pytest --cov=./ --cov-report=xml:coverage.xml --cov-report=html:coverage.html
+    - name: Test with tox (pytest)
+      run: tox -e test
     - name: Archive coverage report
       uses: actions/upload-artifact@v3
       with:
@@ -102,10 +101,7 @@ jobs:
       - name: Build sphinx docs.
         env:
           SPHINXOPTS: '-W'
-        run: |
-          cd docs
-          make clean
-          make html
+        run: tox -e build-docs
         shell: bash
 
   build:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip3 install bandit>=1.7
+          pip3 install bandit>=1.7 tox
         shell: bash
       - name: Run bandit (via tox)
         run: tox -e check-security

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,6 +28,6 @@ jobs:
           python3 -m pip install --upgrade pip
           pip3 install bandit>=1.7
         shell: bash
-      - name: Run bandit
-        run: bandit --severity-level=medium -r package_name
+      - name: Run bandit (via tox)
+        run: tox -e check-security
         shell: bash

--- a/package_name/util.py
+++ b/package_name/util.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import importlib
 import os
 
@@ -5,8 +7,8 @@ from . import __project__  # Keep as relative for templating reasons.
 
 
 def find_package_location(package=__project__):
-    return importlib.util.find_spec(package).submodule_search_locations[0]
+    return Path(importlib.util.find_spec(package).submodule_search_locations[0])
 
 
 def find_repo_location(package=__project__):
-    return os.path.abspath(os.path.join(find_package_location(package), os.pardir))
+    return Path(find_package_location(package) / os.pardir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dev = [
     "pytest",
     "pytest-cov",
     "ruff",
+    "setuptools>=61.2",
+    "setuptools_scm[toml]>=8.0",
     "tox"
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ documentation = "https://github.com/ssec-jhu/base-template"
 repository = "https://github.com/ssec-jhu/base-template"
 
 [build-system]
-requires = ["setuptools>=61.2", "setuptools_scm[toml]>=7"]
+requires = ["setuptools>=61.2", "setuptools_scm[toml]>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 -r prd.txt
 
 bandit==1.7.5
-build==0.10.0
+build==1.0.3
 httpx==0.24.1
 pytest==7.4.0
 pytest-cov==4.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,4 +6,6 @@ httpx==0.24.1
 pytest==7.4.0
 pytest-cov==4.1.0
 ruff==0.0.288
+setuptools==68.2.2
+setuptools_scm[toml]==8.0.3
 tox==4.11.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,0 @@
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup(
-        use_scm_version=True,
-        setup_requires=['setuptools_scm']
-    )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from package_name.util import find_package_location, find_repo_location
 from package_name import __project__, __version__
 
@@ -13,13 +11,14 @@ def test_find_repo_location():
 def test_find_package_location():
     pkg_path = find_package_location()
     assert pkg_path
-    pkg_path = Path(pkg_path)
+    assert pkg_path.exists()
     assert pkg_path.is_dir()
     assert pkg_path.name == __project__
 
 
 def test_version_file():
-    pkg_path = Path(find_package_location())
+    pkg_path = find_package_location()
+    assert pkg_path.exists()
     version_file = pkg_path / "_version.py"
     assert version_file.exists()
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,27 @@
+from pathlib import Path
+
 from package_name.util import find_package_location, find_repo_location
 from package_name import __project__, __version__
+
+
+def test_find_repo_location():
+    repo_path = find_repo_location()
+    assert repo_path
+    assert (repo_path / __project__).exists()
+
+
+def test_find_package_location():
+    pkg_path = find_package_location()
+    assert pkg_path
+    pkg_path = Path(pkg_path)
+    assert pkg_path.is_dir()
+    assert pkg_path.name == __project__
+
+
+def test_version_file():
+    pkg_path = Path(find_package_location())
+    version_file = pkg_path / "_version.py"
+    assert version_file.exists()
 
 
 def test_version():
@@ -8,11 +30,3 @@ def test_version():
 
 def test_project():
     assert __project__
-
-
-def test_find_package_location():
-    assert find_package_location()
-
-
-def test_find_repo_location():
-    assert find_repo_location()


### PR DESCRIPTION
Intended to address versioning fail https://github.com/ssec-jhu/base-template/actions/runs/6339727344/job/17219487997?pr=66#step:6:43
```
 def test_version():
>       assert __version__
E       AssertionError: assert ''
```

Seems like we're not the only ones... https://github.com/pypa/setuptools_scm/issues/933

So ``setup.py`` is totally [deprecated](https://github.com/pypa/setuptools_scm/tree/v7.1.0#setuppy-usage-deprecated) so I've just nuked it and this has done the job. Users in issue 993 state that just removing ``use_scm_version=True`` in ``setup.py`` should have also worked but I didn't bother to verify.