### PR TITLE
Fix codecove in CI from #66

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: code-coverage-report-python${{ matrix.python-version }}-${{ matrix.os }}
-        path: coverage.html
+        path: coverage.xml
         retention-days: 14
         if-no-files-found: error
     - name: Upload coverage to Codecov
@@ -75,7 +75,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         env_vars: OS,PYTHON
         fail_ci_if_error: true
-        files: ./coverage.html
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         verbose: true

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ description = run tests
 passenv = *
 extras = dev
 commands=
-    pytest --cov=./ --cov-report=html:coverage.html {posargs}
+    pytest --cov=./ --cov-report=xml:coverage.xml {posargs}
 
 [testenv:build-docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
Our ``tox`` setup only produces the html report:
```ini
[testenv]
description = run tests
passenv = *
extras = dev
commands=
    pytest --cov=./ --cov-report=html:coverage.html {posargs}
```