### PR TITLE
ignore default autosummary generated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/generated
 
 # PyBuilder
 .pybuilder/


### PR DESCRIPTION
The api docs default uses `toctree: generated`, which is typical but then we should ignore the generated files