### PR TITLE
Add html in addition to xml pytest coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ description = run tests
 passenv = *
 extras = dev
 commands=
-    pytest --cov=./ --cov-report=xml:coverage.xml {posargs}
+    pytest --cov=./ --cov-report=html:coverage.html --cov-report=xml:coverage.xml {posargs}
 
 [testenv:build-docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
html is more readable in a local setting, while the xml is consumed by codecov for PRs and mainline commits.