### PR TITLE
Build latex and epub in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ allowlist_externals=make
 change_dir = docs
 setenv =
     SPHINXOPTS=-W
-commands = make html
+commands = make clean html latex epub
 
 [testenv:build-dist]
 description = build


### PR DESCRIPTION
Since RTD doesn't do other formats in autobuild [1], try to cover as much as possible in the tox test. For now pdf is not generated, but latex is.

[1] https://docs.readthedocs.io/en/stable/guides/pull-requests.html#limitations