### PR TITLE
Don't use login shell for test action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install -r requirements/dev.txt
-      shell: bash -l {0}
+      shell: bash
     - name: pip install package
       run: pip install .
     - name: Test with tox (pytest)


### PR DESCRIPTION
The use of the login shell effectively "forgot" the installed python environment and in certain cases lead to failure with the build if the underlying system has a python version that does not match what was meant to test (see also [1]). Removing the -l allows test to use the previously installed python (in setup-python action).

[1] https://github.com/actions/runner-images/issues/8839