### PR TITLE
Use GitHub actions cache for pip deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
@@ -53,6 +54,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
@@ -92,6 +94,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip


### PR DESCRIPTION
This should speed up CI testing (also decreasing cost) by caching our pip dependencies.