### PR TITLE
Use requirements files in tox

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ For additional cmds see the [Conda cheat-sheet](https://docs.conda.io/projects/c
  * Activate/switch to new env ``conda activate <environment_name>``
  * ``cd`` into repo dir.
  * Install ``python`` and ``pip`` ``conda install python=3.11 pip``
- * Install all required dependencies (assuming local dev work) ``pip install -r requirements/dev.txt``.
+ * Install all required dependencies (assuming local dev work), there are two ways to do this
+   * If working with tox (recommended) ``pip install -r requirements/dev.txt``.
+   * If you would like to setup an environment with all requirements to run outside of tox ``pip install -r requirements/all.txt``.
 
 ### Build:
 
@@ -80,6 +82,19 @@ To be completed by child repo.
 
 # Testing
 _NOTE: The following steps require ``pip install -r requirements/dev.txt``._
+
+## Using tox
+
+* Run tox ``tox``. This will run all of linting, security, test, docs and package building within tox virtual environments.
+* To run an individual step, use ``tox -e {step}`` for example, ``tox -e test``, ``tox -e build-docs``, etc.
+
+Typically, the CI tests run in github actions will use tox to run as above. See also [ci.yml](https://github.com/ssec-jhu/base-template/blob/main/.github/workflows/ci.yml).
+
+## Outside of tox:
+
+The below assume you are running steps without tox, and that all requirements are installed into a conda environment, e.g. with ``pip install -r requirements/all.txt``.
+
+_NOTE: Tox will run these for you, this is specifically if there is a requirement to setup environment and run these outside the purview of tox._
 
 ### Linting:
 Facilitates in testing typos, syntax, style, and other simple code analysis tests.

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -1,0 +1,4 @@
+-r prd.txt
+-r build.txt
+-r test.txt
+-r docs.txt

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,3 @@
+build==1.0.3
+setuptools==69.0.3
+setuptools_scm[toml]==8.0.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,11 +1,1 @@
--r prd.txt
-
-bandit==1.7.5
-build==1.0.3
-httpx==0.26.0
-pytest==8.0.0
-pytest-cov==4.1.0
-ruff==0.1.15
-setuptools==69.0.3
-setuptools_scm[toml]==8.0.4
 tox==4.12.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,4 @@
+bandit==1.7.5
+ruff==0.1.15
+pytest==8.0.0
+pytest-cov==4.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
 description = check code style
 skip_install = true
 deps =
-    ruff
+    -r requirements/test.txt
 commands =
     ruff . {posargs}
 
@@ -18,7 +18,7 @@ commands =
 description = run bandit to check security compliance
 skip_install = true
 deps =
-    bandit>=1.7
+    -r requirements/test.txt
 commands =
     bandit -c pyproject.toml --severity-level=medium -r package_name
 
@@ -26,6 +26,9 @@ commands =
 description = run tests
 passenv = *
 extras = dev
+deps =
+    -r requirements/test.txt
+    -r requirements/prd.txt
 commands=
     pytest --cov=./ --cov-report=html:coverage.html --cov-report=xml:coverage.xml {posargs}
 
@@ -36,12 +39,14 @@ allowlist_externals=make
 change_dir = docs
 setenv =
     SPHINXOPTS=-W
+deps =
+    -r requirements/docs.txt
 commands = make clean html latex epub
 
 [testenv:build-dist]
 description = build
 skip_install = true
 deps =
-    build
+    -r requirements/build.txt
 commands =
     python -m build


### PR DESCRIPTION
Separate dependencies for tox itself and test/build/docs to isolate from production dependencies as much as possible.

This is a proposal for requirements and leveraging tox to do the testing and building in its isolated environments. This limits the chances of dependency conflicts between production requirements and those for building insofar as possible. Technically, the only requirement for the developers local environment is that in dev.txt which should just be tox.

If we don't do this, we still should be using the requirements files for tox build, so a change along these lines is till necessary. Please let me know what you think. This is how things are done in the dplutils package, partly because ray has some conflicts with tox itself, for example.