### PR TITLE
Expand default ruff checks

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -5,7 +5,7 @@
 
 
 echo Running ruff linter tests...
-TEST_RESULTS=$(ruff .)
+TEST_RESULTS=$(tox -e check-style)
 RETURN_VALUE=$?
 if [ $RETURN_VALUE != 0 ]; then
   echo "$TEST_RESULTS"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,15 @@ exclude_dirs = ["tests"]
 
 [tool.ruff]
 line-length = 120
+lint.select = ["ALL"]
+lint.ignore = [
+    "ANN",
+    "PLR0913",
+    "EM101",
+    "EM102",
+    "TRY003",
+    "D407",
+]
 exclude = [
     ".bzr",
     ".direnv",
@@ -78,8 +87,17 @@ exclude = [
     "venv",
     "_version.py"
 ]
+target-version = "py311"
 
-lint.ignore = [
+[tool.ruff.lint.per-file-ignores]
+"**/test{s,}/*.py" = [
+     "S101",
+    "D",
+    "ARG001",
+    "INP",
 ]
 
-target-version = "py311"
+[tool.ruff.flake8-quotes]
+docstring-quotes = "double"
+inline-quotes = "single"
+multiline-quotes = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,12 @@ exclude_dirs = ["tests"]
 line-length = 120
 lint.select = ["ALL"]
 lint.ignore = [
-    "ANN",
-    "PLR0913",
-    "EM101",
-    "EM102",
-    "TRY003",
-    "D407",
+    "ANN",  # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+    "PLR0913",  # https://docs.astral.sh/ruff/rules/too-many-arguments/
+    "EM101",  # https://docs.astral.sh/ruff/rules/raw-string-in-exception/
+    "EM102",  # https://docs.astral.sh/ruff/rules/f-string-in-exception/
+    "TRY003",  # https://docs.astral.sh/ruff/rules/raise-vanilla-args/
+    "D407",  # https://docs.astral.sh/ruff/rules/dashed-underline-after-section/
 ]
 exclude = [
     ".bzr",
@@ -91,13 +91,13 @@ target-version = "py311"
 
 [tool.ruff.lint.per-file-ignores]
 "**/test{s,}/*.py" = [
-     "S101",
-    "D",
-    "ARG001",
-    "INP",
+    "S101",  # https://docs.astral.sh/ruff/rules/assert/
+    "D",  # https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "ARG001",  # https://docs.astral.sh/ruff/rules/unused-function-argument/
+    "INP",  # https://docs.astral.sh/ruff/rules/#flake8-no-pep420-inp
 ]
 
-[tool.ruff.flake8-quotes]
-docstring-quotes = "double"
-inline-quotes = "single"
-multiline-quotes = "double"
+[tool.ruff.lint.flake8-quotes]
+docstring-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_docstring-quotes
+inline-quotes = "single"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_inline-quotes
+multiline-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_multiline-quotes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,11 @@ exclude_dirs = ["tests"]
 line-length = 120
 lint.select = ["ALL"]
 lint.ignore = [
-    "ANN",  # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+    "ANN002",  # https://docs.astral.sh/ruff/rules/missing-type-args/
+    "ANN003",  # https://docs.astral.sh/ruff/rules/missing-type-kwargs/
+    "ANN101",  # https://docs.astral.sh/ruff/rules/missing-type-self/
+    "ANN102",  # https://docs.astral.sh/ruff/rules/missing-type-cls/
+    "ANN401",  # https://docs.astral.sh/ruff/rules/any-type/
     "PLR0913",  # https://docs.astral.sh/ruff/rules/too-many-arguments/
     "EM101",  # https://docs.astral.sh/ruff/rules/raw-string-in-exception/
     "EM102",  # https://docs.astral.sh/ruff/rules/f-string-in-exception/
@@ -95,6 +99,7 @@ target-version = "py311"
     "D",  # https://docs.astral.sh/ruff/rules/#pydocstyle-d
     "ARG001",  # https://docs.astral.sh/ruff/rules/unused-function-argument/
     "INP",  # https://docs.astral.sh/ruff/rules/#flake8-no-pep420-inp
+    "ANN",  # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
 ]
 
 [tool.ruff.lint.flake8-quotes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,5 +99,5 @@ target-version = "py311"
 
 [tool.ruff.lint.flake8-quotes]
 docstring-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_docstring-quotes
-inline-quotes = "single"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_inline-quotes
+inline-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_inline-quotes
 multiline-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_multiline-quotes

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,9 @@ skip_install = true
 deps =
     -r requirements/test.txt
 commands =
-    ruff check . --exit-zero {posargs}
     ruff check . --select E --select F {posargs}
+    # NB: New projects should consider replacing the above with below!
+    # ruff check . {posargs}
 
 [testenv:check-security]
 description = run bandit to check security compliance

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,8 @@ skip_install = true
 deps =
     -r requirements/test.txt
 commands =
-    ruff . {posargs}
+    ruff check . --exit-zero {posargs}
+    ruff check . --select E --select F {posargs}
 
 [testenv:check-security]
 description = run bandit to check security compliance


### PR DESCRIPTION
We seem to be missing out on a lot of good checks and hints by using only the defaults. This expands the set while setting up some ignores.

However, don't fail the check except for the ones we are used to.

**Notes**:
* The tox check is meant to be more compatible with what we already have, so it wont fail but just report new violations. In this way it is more for hints in the IDE and setting some shared guidelines (e.g. in what we choose to check/ignore)
* For whole new projects, we might want to remove the `--select` from tox check-style and be a bit stricter from the start, but that can be per project.
* For existing projects we can backport this and keep the tox check, which should open up some nice hints, and any desired fixes can be done along the way.
* For things already transitioned, we wouldn't bother backporting.
* ❗ I just chose a handful of ignores that I don't care too much about, happy for updates to that set 😄 