### PR TITLE
Added formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,31 @@ jobs:
         run: tox -e check-style
         shell: bash
 
+  format-check:
+    name: check format with ruff with Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install -r requirements/dev.txt
+        shell: bash
+      - name: Check code formatting
+        run: tox -e format-code -- --check
+        shell: bash
+      - name: Check import formatting
+        run: tox -e format-imports -- --exit-non-zero-on-fix
+        shell: bash
+
   test:
     name: pytests on Python ${{ matrix.python-version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   lint:
-    name: lint and check style with ruff with Python ${{ matrix.python-version }}
+    name: lint with ruff with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   lint:
-    name: lint with ruff with Python ${{ matrix.python-version }}
+    name: lint and check style with ruff with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,31 +35,6 @@ jobs:
         shell: bash
       - name: Lint
         run: tox -e check-style
-        shell: bash
-
-  format-check:
-    name: check format with ruff with Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.11]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install -r requirements/dev.txt
-        shell: bash
-      - name: Check code formatting
-        run: tox -e format-code -- --check
-        shell: bash
-      - name: Check import formatting
-        run: tox -e format-imports -- --exit-non-zero-on-fix
         shell: bash
 
   test:

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -3,6 +3,15 @@
 # To use this githook copy this file to .git/hooks (in repo root dir)
 # The file permissions may need changing using ``chmod +x .git/hooks/pre-push``
 
+echo Running formatter...
+TEST_RESULTS=$(tox -e format)
+RETURN_VALUE=$?
+if [ $RETURN_VALUE != 0 ]; then
+  echo "$TEST_RESULTS"
+  exit 1
+fi
+echo Finished
+exit 0
 
 echo Running ruff linter tests...
 TEST_RESULTS=$(tox -e check-style)

--- a/package_name/__init__.py
+++ b/package_name/__init__.py
@@ -3,4 +3,4 @@ __project__ = "package_name"  # Replace package_name with actual name (it's just
 try:
     from ._version import __version__
 except ImportError:
-    __version__ = ''
+    __version__ = ""

--- a/package_name/app/main.py
+++ b/package_name/app/main.py
@@ -8,7 +8,7 @@ app = FastAPI()
 
 @app.get("/")
 async def root():
-    return RedirectResponse(url='/docs')
+    return RedirectResponse(url="/docs")
 
 
 @app.get("/healthz")

--- a/package_name/util.py
+++ b/package_name/util.py
@@ -1,7 +1,6 @@
-from pathlib import Path
-
 import importlib
 import os
+from pathlib import Path
 
 from . import __project__  # Keep as relative for templating reasons.
 

--- a/project_setup.py
+++ b/project_setup.py
@@ -1,4 +1,5 @@
 """Helps setup a new project based on this template."""
+
 import argparse
 import functools
 import os
@@ -19,12 +20,13 @@ UPDATED_DIR = "Renamed {old_dir} to {new_dir} ✅"
 UPDATED_FILE = "Updated package_name to {package_name} in {file_path} ✅"
 SETUP_COMPLETE = "{package_name} setup complete! 🎉🎉🎉\n"
 
-def make_name_safe(name:str) -> str:
+
+def make_name_safe(name: str) -> str:
     """Makes a string safe to use as a package name."""
-    return name.lower().replace(' ', '_').replace('-', '_')
+    return name.lower().replace(" ", "_").replace("-", "_")
 
 
-def valid_file_predicate(file_path:Path) -> bool:
+def valid_file_predicate(file_path: Path) -> bool:
     """Checks if a file is valid for modification."""
     is_valid_extension = file_path.suffix not in [
         # images
@@ -39,15 +41,15 @@ def valid_file_predicate(file_path:Path) -> bool:
 
 
 def get_package_name(
-    repo_url:str,
+    repo_url: str,
 ) -> str:
     """Guesses the package name from the repo URL."""
     return make_name_safe(Path(repo_url).stem)
 
 
 def replace_file_contents(
-    pairs_to_replace:List[Tuple[str, str]],
-    file_path:Path,
+    pairs_to_replace: List[Tuple[str, str]],
+    file_path: Path,
 ) -> bool:
     """Replaces the contents of a file.
 
@@ -71,7 +73,7 @@ def replace_file_contents(
     return False
 
 
-def self_destruct(parent_dir:Path = Path(".")) -> None:
+def self_destruct(parent_dir: Path = Path(".")) -> None:
     """Deletes this file and its tests."""
     os.remove(parent_dir / Path(__file__).name)
     os.remove(parent_dir / Path("tests/test_project_setup.py"))
@@ -87,24 +89,24 @@ def self_destruct(parent_dir:Path = Path(".")) -> None:
 
 
 def rtd_project_guess(
-    repo_url:str,
+    repo_url: str,
 ) -> str:
     """Guesses the RTD project name from the repo URL."""
     return Path(repo_url).stem
 
 
 def codecov_project_guess(
-    repo_url:str,
+    repo_url: str,
 ) -> str:
     """Guesses the codecov project name from the repo URL."""
     return "/".join(Path(repo_url).parts[-2:]).replace(".git", "")
 
 
 def run_setup(
-    repo_url:str,
-    package_name:str,
-    repo:git.Repo = git.Repo(),
-    commit_as_you_go:bool = True,
+    repo_url: str,
+    package_name: str,
+    repo: git.Repo = git.Repo(),
+    commit_as_you_go: bool = True,
 ) -> None:
     """Helper to setup a new project based on this template.
 
@@ -124,16 +126,20 @@ def run_setup(
     Returns:
         None
     """
-    def commit_func(message:str) -> None:
-        repo.git.commit(*list(filter(
-            lambda arg: len(arg) > 0,
-            [
-                "--dry-run" if not commit_as_you_go else "",
-                "-qam",
-                message,
-            ]
-        )))
 
+    def commit_func(message: str) -> None:
+        repo.git.commit(
+            *list(
+                filter(
+                    lambda arg: len(arg) > 0,
+                    [
+                        "--dry-run" if not commit_as_you_go else "",
+                        "-qam",
+                        message,
+                    ],
+                )
+            )
+        )
 
     # Step 1: Update the pyproject.toml and README.md ==========================
     rtd_guess = rtd_project_guess(repo_url)
@@ -164,12 +170,12 @@ def run_setup(
     # Step 2: Update the package_name in all files =============================
 
     # filter out files that we don't want to modify
-    files_to_check = list(filter(
-        valid_file_predicate,
-        map(
-            lambda f: Path(repo.working_dir) / Path(f),
-            repo.git.ls_tree("-r", "--name-only", "HEAD").split("\n")),
-    ))
+    files_to_check = list(
+        filter(
+            valid_file_predicate,
+            map(lambda f: Path(repo.working_dir) / Path(f), repo.git.ls_tree("-r", "--name-only", "HEAD").split("\n")),
+        )
+    )
 
     # order matters, replace the bracketed version first
     package_name_replacement_pairs = [
@@ -180,8 +186,6 @@ def run_setup(
         # only print positive results
         if replace_file_contents(package_name_replacement_pairs, file_path):
             print(UPDATED_FILE.format(package_name=package_name, file_path=file_path))
-
-
 
     # Step 3: Rename the package_name directory ================================
     repo.git.mv(TEMPLATE_PACKAGE_NAME, package_name)
@@ -197,7 +201,7 @@ def run_setup(
     print(SETUP_COMPLETE.format(package_name=package_name))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--repo_url",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ lint.ignore = [
     "EM102",  # https://docs.astral.sh/ruff/rules/f-string-in-exception/
     "TRY003",  # https://docs.astral.sh/ruff/rules/raise-vanilla-args/
     "D407",  # https://docs.astral.sh/ruff/rules/dashed-underline-after-section/
+    "COM812", # https://docs.astral.sh/ruff/rules/missing-trailing-comma/
+    "ISC001", # https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/
 ]
 exclude = [
     ".bzr",
@@ -92,6 +94,9 @@ exclude = [
     "_version.py"
 ]
 target-version = "py311"
+
+[tool.ruff.lint.pydocstyle] # https://docs.astral.sh/ruff/settings/#lint_pydocstyle_convention
+convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "**/test{s,}/*.py" = [

--- a/tests/test_project_setup.py
+++ b/tests/test_project_setup.py
@@ -1,6 +1,6 @@
 import os
-from pathlib import Path
 import shutil
+from pathlib import Path
 from typing import List, Tuple
 
 # this is GitPython
@@ -9,52 +9,62 @@ import pytest
 
 import project_setup as ps
 
-@pytest.mark.parametrize("name, expected", [
-    ("My Project", "my_project"),
-    ("My-Project", "my_project"),
-    ("My_Project", "my_project"),
-    ("My_Pro-ject", "my_pro_ject"),
-    ("my_project", "my_project"),
-    ("", "")
-])
-def test_make_name_safe(name:str, expected:str):
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("My Project", "my_project"),
+        ("My-Project", "my_project"),
+        ("My_Project", "my_project"),
+        ("My_Pro-ject", "my_pro_ject"),
+        ("my_project", "my_project"),
+        ("", ""),
+    ],
+)
+def test_make_name_safe(name: str, expected: str):
     assert ps.make_name_safe(name) == expected
 
 
-@pytest.mark.parametrize("file_path, expected", [
-    (Path("test.png"), False),
-    (Path("test.jpg"), False),
-    (Path("test.jpeg"), False),
-    (Path(".DS_Store"), False),
-    (Path("project_setup.py"), False),
-    (Path("great_idea.py"), True),
-    (Path("science.txt"), True),
-    (Path("new_ideas.md"), True),
-])
-def test_valid_file_predicate(file_path:Path, expected:bool):
+@pytest.mark.parametrize(
+    "file_path, expected",
+    [
+        (Path("test.png"), False),
+        (Path("test.jpg"), False),
+        (Path("test.jpeg"), False),
+        (Path(".DS_Store"), False),
+        (Path("project_setup.py"), False),
+        (Path("great_idea.py"), True),
+        (Path("science.txt"), True),
+        (Path("new_ideas.md"), True),
+    ],
+)
+def test_valid_file_predicate(file_path: Path, expected: bool):
     assert ps.valid_file_predicate(file_path) == expected
 
 
 @pytest.mark.parametrize(
-    "repo_url, expected_output", [
-    (
-        "https://github.com/example/good-idea.git",
-        "good_idea",
-    ),
-    (
-        "https://github.com/example/bet-ter-id_ea.git",
-        "bet_ter_id_ea",
-    ),
-])
+    "repo_url, expected_output",
+    [
+        (
+            "https://github.com/example/good-idea.git",
+            "good_idea",
+        ),
+        (
+            "https://github.com/example/bet-ter-id_ea.git",
+            "bet_ter_id_ea",
+        ),
+    ],
+)
 def test_get_package_name(
-    repo_url:str,
-    expected_output:str,
+    repo_url: str,
+    expected_output: str,
 ):
-    assert ps.get_package_name(repo_url)==expected_output
+    assert ps.get_package_name(repo_url) == expected_output
 
 
 @pytest.mark.parametrize(
-    "file_contents, replacement_tuple, expected", [
+    "file_contents, replacement_tuple, expected",
+    [
         # old texts exists and is replaced
         (
             "This is a file\nwith old_text\nand more text\n",
@@ -62,17 +72,13 @@ def test_get_package_name(
             True,
         ),
         # old text does not exist
-        (
-            "This is a file\nwith some text\nand more text\n",
-            [("old_text", "new_text")],
-            False
-        ),
-    ]
+        ("This is a file\nwith some text\nand more text\n", [("old_text", "new_text")], False),
+    ],
 )
 def test_replace_file_contents(
-    file_contents:str,
-    replacement_tuple:List[Tuple[str, str]],
-    expected:bool,
+    file_contents: str,
+    replacement_tuple: List[Tuple[str, str]],
+    expected: bool,
 ):
     with open("tmp.txt", "w") as f:
         f.write(file_contents)
@@ -117,37 +123,41 @@ def test_self_destruct(tmp_path):
     assert "GitPython" not in dev_requirements
     assert "GitPython" not in test_requirements
 
+
 @pytest.mark.parametrize(
-    "repo_url, expected", [
+    "repo_url, expected",
+    [
         ("https://www.github.com/amazing-org/really-great-project.git", "really-great-project"),
-    ]
+    ],
 )
-def test_rtd_project_guess(repo_url:str, expected:str):
+def test_rtd_project_guess(repo_url: str, expected: str):
     assert ps.rtd_project_guess(repo_url) == expected
 
 
 @pytest.mark.parametrize(
-    "repo_url, expected", [
+    "repo_url, expected",
+    [
         ("https://www.github.com/amazing-org/really-great-project.git", "amazing-org/really-great-project"),
-    ]
+    ],
 )
-def test_codecov_project_guess(repo_url:str, expected:str):
+def test_codecov_project_guess(repo_url: str, expected: str):
     assert ps.codecov_project_guess(repo_url) == expected
 
 
 @pytest.mark.parametrize(
-    "repo_url, package_name", [
-    ("https://www.github.com/good-org/amazing-project.git", "amazing_project"),
-])
-def test_run_setup(repo_url:str, package_name:str, tmp_path):
-
+    "repo_url, package_name",
+    [
+        ("https://www.github.com/good-org/amazing-project.git", "amazing_project"),
+    ],
+)
+def test_run_setup(repo_url: str, package_name: str, tmp_path):
     def with_tmp(f):
         return tmp_path / f
 
     shutil.copytree(os.getcwd(), tmp_path, dirs_exist_ok=True)
 
     repo = git.Repo(tmp_path)
-    #sign in to the repo
+    # sign in to the repo
     repo.git.config("user.email", "ssec@jhu.edu")
     repo.git.config("user.name", "ssec")
 
@@ -198,4 +208,3 @@ def test_run_setup(repo_url:str, package_name:str, tmp_path):
     # check the other.py
     assert template_package_name not in actual_util
     assert package_name not in actual_util
-

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
-from package_name.util import find_package_location, find_repo_location
 from package_name import __project__, __version__
+from package_name.util import find_package_location, find_repo_location
 
 
 def test_find_repo_location():

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 [tox]
 envlist =
     check-{style,security}
+    format
     test
     build-{docs,dist}
 
@@ -23,6 +24,22 @@ deps =
     -r requirements/test.txt
 commands =
     bandit -c pyproject.toml --severity-level=medium -r package_name
+
+[testenv:format-code]
+description = format code
+skip_install = true
+deps =
+    -r requirements/test.txt
+commands =
+    ruff format . {posargs}
+
+[testenv:format-imports]
+description = format code
+skip_install = true
+deps =
+    -r requirements/test.txt
+commands =
+    ruff check --select I --fix . {posargs}
 
 [testenv]
 description = run tests

--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,10 @@ skip_install = true
 deps =
     -r requirements/test.txt
 commands =
-    ruff check . --select E --select F {posargs}
+    ruff format . --check {posargs}
+    ruff check . --select E --select F --select I {posargs}
     # NB: New projects should consider replacing the above with below!
     # ruff check . {posargs}
-
-    # below are formatter checks
-    ruff format . --check {posargs}
-    ruff check . --select  I {posargs}
 
 [testenv:check-security]
 description = run bandit to check security compliance

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,10 @@ commands =
     # NB: New projects should consider replacing the above with below!
     # ruff check . {posargs}
 
+    # below are formatter checks
+    ruff format . --check {posargs}
+    ruff check . --select  I {posargs}
+
 [testenv:check-security]
 description = run bandit to check security compliance
 skip_install = true
@@ -25,20 +29,13 @@ deps =
 commands =
     bandit -c pyproject.toml --severity-level=medium -r package_name
 
-[testenv:format-code]
-description = format code
+[testenv:format]
+description = format code and sort imports using ruff
 skip_install = true
 deps =
     -r requirements/test.txt
 commands =
     ruff format . {posargs}
-
-[testenv:format-imports]
-description = format code
-skip_install = true
-deps =
-    -r requirements/test.txt
-commands =
     ruff check --select I --fix . {posargs}
 
 [testenv]


### PR DESCRIPTION
This  PR adds automated code formatting and import sorting via ruff.

More information about the ruff formatter can be found here: 
https://docs.astral.sh/ruff/formatter/

Sorting imports is done by selecting the `I` rule and using `--fix` with the ruff linter. There is another tool for this called `isort` which is a popular choice, but using ruff seems to be close to that and doesn't involve installing another tool. I am happy to switch to that if we want.

I ran the formatter on the template so you'll see some misc changes to files that are not the github action or tox  configurations.