### PR TITLE
Don't auto format from git hook

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -3,21 +3,12 @@
 # To use this githook copy this file to .git/hooks (in repo root dir)
 # The file permissions may need changing using ``chmod +x .git/hooks/pre-push``
 
-echo Running formatter...
-TEST_RESULTS=$(tox -e format)
-RETURN_VALUE=$?
-if [ $RETURN_VALUE != 0 ]; then
-  echo "$TEST_RESULTS"
-  exit 1
-fi
-echo Finished
-exit 0
-
 echo Running ruff linter tests...
 TEST_RESULTS=$(tox -e check-style)
 RETURN_VALUE=$?
 if [ $RETURN_VALUE != 0 ]; then
   echo "$TEST_RESULTS"
+  echo "To auto format run: tox -e format"
   exit 1
 fi
 echo PASSED


### PR DESCRIPTION
It's ok for the hook to check, which it does, but not actually make any changes.

If I suggested otherwise in the past, my bad!