### PR TITLE
excluding module-level tests in built package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,13 @@ requires = ["setuptools>=61.2", "setuptools_scm[toml]>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["package_name"]  # Replace package_name with actual name (it's just a template).
 zip-safe = false
 include-package-data = true
+exclude-package-data = {"*" = ["tests/*"]}
+
+[tool.setuptools.packages.find]
+include = ["package_name*"]
+exclude = ["*.tests*"]
 
 [tool.setuptools_scm]
 write_to = "package_name/_version.py"  # Replace package_name with actual name (it's just a template).


### PR DESCRIPTION
I noticed that our default settings for packaging was including module-level tests, for example, for this repository prior to this change:

(abbreviated build-dist log)
```
creating '/Users/arik/ws/ssec/base-template/dist/.tmp-buyh8295/package_name-0.1.dev245+g96a6749-py3-none-any.whl' and adding 'build/bdist.macosx-11.0-arm64/wheel' to it
adding 'package_name/__init__.py'
adding 'package_name/_version.py'
adding 'package_name/util.py'
adding 'package_name/app/__init__.py'
adding 'package_name/app/main.py'
adding 'package_name/app/tests/__init__.py'
adding 'package_name/app/tests/conftest.py'
adding 'package_name/app/tests/test_app.py'
adding 'package_name-0.1.dev245+g96a6749.dist-info/LICENSE'
adding 'package_name-0.1.dev245+g96a6749.dist-info/METADATA'
adding 'package_name-0.1.dev245+g96a6749.dist-info/WHEEL'
adding 'package_name-0.1.dev245+g96a6749.dist-info/top_level.txt'
adding 'package_name-0.1.dev245+g96a6749.dist-info/RECORD'
removing build/bdist.macosx-11.0-arm64/wheel
Successfully built package_name-0.1.dev245+g96a6749.tar.gz and package_name-0.1.dev245+g96a6749-py3-none-any.whl
  build-dist: OK (3.08=setup[0.02]+cmd[3.06] seconds)
  congratulations :) (3.11 seconds)
```

And after this change:
```
creating '/Users/arik/ws/ssec/base-template/dist/.tmp-j4v6v9zc/package_name-0.1.dev246+gb6988ae-py3-none-any.whl' and adding 'build/bdist.macosx-11.0-arm64/wheel' to it
adding 'package_name/__init__.py'
adding 'package_name/_version.py'
adding 'package_name/util.py'
adding 'package_name/app/__init__.py'
adding 'package_name/app/main.py'
adding 'package_name-0.1.dev246+gb6988ae.dist-info/LICENSE'
adding 'package_name-0.1.dev246+gb6988ae.dist-info/METADATA'
adding 'package_name-0.1.dev246+gb6988ae.dist-info/WHEEL'
adding 'package_name-0.1.dev246+gb6988ae.dist-info/top_level.txt'
adding 'package_name-0.1.dev246+gb6988ae.dist-info/RECORD'
removing build/bdist.macosx-11.0-arm64/wheel
Successfully built package_name-0.1.dev246+gb6988ae.tar.gz and package_name-0.1.dev246+gb6988ae-py3-none-any.whl
  build-dist: OK (3.09=setup[0.02]+cmd[3.07] seconds)
  congratulations :) (3.12 seconds)
```