### PR TITLE
Adding github-pages autogeneration to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
   docs:
     name: Build docs with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    # need permission to create the ghpages branch in GitHub
+    permissions:
+      contents: write
     strategy:
       matrix:
         python-version: [ 3.11 ]
@@ -101,10 +104,19 @@ jobs:
           pip3 install -r requirements/docs.txt
         shell: bash
       - name: Build sphinx docs.
-        env:
-          SPHINXOPTS: '-W'
+        # Uncomment if you want all warning to be treated as errors. Note this will prevent the GitHub page update
+        #env:
+        #  SPHINXOPTS: '-W'
         run: tox -e build-docs
         shell: bash
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        # build if push is on the main branch
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html
+          force_orphan: true # Without this, the gh-pages branch may accumulate old commits and get messy.
 
   build:
     name: Build and Publish.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+      - name: Install tox
+        run: python -m pip install tox
+        shell: bash
       - name: Build sphinx docs.
         # Comment the env: SPHINXOPTS if you want to ignore warnings during doc build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: [3.11]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -48,7 +48,7 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
           lfs: true
     - uses: actions/setup-python@v4
@@ -92,7 +92,7 @@ jobs:
       matrix:
         python-version: [ 3.11 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -128,7 +128,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,11 @@ jobs:
   docs:
     name: Build docs with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    # need permission to create the ghpages branch in GitHub
+    # need permissions to deploy to GitHub Pages
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
     strategy:
       matrix:
         python-version: [ 3.11 ]
@@ -98,25 +100,21 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install -r requirements/docs.txt
-        shell: bash
       - name: Build sphinx docs.
-        # Uncomment if you want all warning to be treated as errors. Note this will prevent the GitHub page update
-        #env:
-        #  SPHINXOPTS: '-W'
+        # Comment the env: SPHINXOPTS if you want to ignore warnings during doc build
+        env:
+         SPHINXOPTS: '-W'
         run: tox -e build-docs
         shell: bash
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        # build if push is on the main branch
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build/html
-          force_orphan: true # Without this, the gh-pages branch may accumulate old commits and get messy.
+          path: ./docs/_build/html
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
   build:
     name: Build and Publish.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # SSEC-JHU <package_name>
 
 [![CI](https://github.com/ssec-jhu/base-template/actions/workflows/ci.yml/badge.svg)](https://github.com/ssec-jhu/base-template/actions/workflows/ci.yml)
-[![Documentation Status](https://readthedocs.org/projects/ssec-jhu-base-template/badge/?version=latest)](https://ssec-jhu-base-template.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/ssec-jhu/base-template/branch/main/graph/badge.svg?token=0KPNKHRC2V)](https://codecov.io/gh/ssec-jhu/base-template)
 [![Security](https://github.com/ssec-jhu/base-template/actions/workflows/security.yml/badge.svg)](https://github.com/ssec-jhu/base-template/actions/workflows/security.yml)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14052740.svg)](https://doi.org/10.5281/zenodo.14052740)
@@ -20,6 +19,8 @@ Things to do when using this template:
  * Import package into https://readthedocs.org/.
  * Update [zenodo.json](zenodo.json). For more details see [zenodo.json docs](https://developers.zenodo.org/#representation) and [zenodo docs on contributors vs creators](https://help.zenodo.org/docs/deposit/describe-records/contributors/).
  * Update quickstart guide below.
+ * Go to https://github.com/ssec-jhu/<repo-name>/settings/pages and set the "source"
+   field for "Build and deployment" to "GitHub Actions".
 
 What's included in this template:
 
@@ -31,6 +32,7 @@ What's included in this template:
  * Dockerfile.
  * Pytest example(s).
  * Githooks.
+ * Docs that build and deploy to https://ssec-jhu.github.io/base-template
 
 # Quickstart Guide
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ setenv =
     SPHINXOPTS=-W
 deps =
     -r requirements/docs.txt
-commands = make clean html latex epub
+commands = make clean html
 
 [testenv:build-dist]
 description = build


### PR DESCRIPTION
The addition to the CI will automatically create a gh-pages branch upon merging any PR to main.
User must then select the branch in Github Pages (image below) one time and the docs will be set up in the repo at 
`https://ssec-jhu.github.io/<repo-name>/`

<img width="773" height="250" alt="Screenshot 2025-12-03 at 11 06 24 AM" src="https://github.com/user-attachments/assets/7b911b73-1217-441d-8eeb-47e8287f24d4" />
