### PR TITLE
Replace codecov with GH Actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ omit =
     setup.py
     */tests/*
     _version.py
+    coverage_writer.py
 [report]
 exclude_lines =
     @abstractmethod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,16 +71,15 @@ jobs:
         path: coverage.xml
         retention-days: 14
         if-no-files-found: error
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+    - name: Evaluate Diff Coverage
+      id: diff-coverage
+      uses: Affanmir/diff-cover-action@v2.1.0
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        env_vars: OS,PYTHON
-        fail_ci_if_error: true
-        files: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        verbose: true
+        coverage-files: coverage.xml
+        config-file: pyproject.toml
+        create-annotations: false
+
+
 
   docs:
     name: Build docs with Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
   test:
     name: pytests on Python ${{ matrix.python-version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       matrix:
         python-version: [3.11]
@@ -51,6 +54,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
           lfs: true
+          fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
           python-version: ${{ matrix.python-version }}
@@ -64,6 +68,9 @@ jobs:
       run: pip install .
     - name: Test with tox (pytest)
       run: tox -e test
+    - name: Extract coverage information
+      id: cov_outputs
+      run: python coverage_writer.py
     - name: Archive coverage report
       uses: actions/upload-artifact@v4.4.3
       with:
@@ -71,15 +78,38 @@ jobs:
         path: coverage.xml
         retention-days: 14
         if-no-files-found: error
-    - name: Evaluate Diff Coverage
+    - name: Evaluate Codebase Coverage
+      uses: 5monkeys/cobertura-action@v14
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        path: coverage.xml
+        minimum_coverage: 90
+        fail_below_threshold: true
+    - name: Evaluate Patch Coverage
+      if: github.event_name == 'pull_request'
       id: diff-coverage
       uses: Affanmir/diff-cover-action@v2.1.0
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         coverage-files: coverage.xml
         config-file: pyproject.toml
-        create-annotations: false
-
-
+        create-annotations: true
+    - name: Generate and Commit Coverage Badge
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jaywcjlove/generated-badges@v1.1.0
+      with:
+        label: Coverage
+        output: coverage.svg
+        status: ${{ steps.cov_outputs.outputs.percent }}
+        color: ${{ steps.cov_outputs.outputs.color }}
+    - name: Commit coverage badge
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: stefanzweifel/git-auto-commit-action@v7.1.0
+      with:
+        commit_message: "[skip ci] Update coverage badge"
+        file_pattern: coverage.svg
+        branch: badges
+        commit_options: '--no-verify --signoff'
 
   docs:
     name: Build docs with Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       run: pip install .
     - name: Test with tox (pytest)
       run: tox -e test
-    - name: Extract coverage information
+    - name: Extract coverage information for badges
       id: cov_outputs
       run: python coverage_writer.py
     - name: Archive coverage report
@@ -94,7 +94,7 @@ jobs:
         coverage-files: coverage.xml
         config-file: pyproject.toml
         create-annotations: true
-    - name: Generate and Commit Coverage Badge
+    - name: Generate coverage Badge
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jaywcjlove/generated-badges@v1.1.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
         path: coverage.xml
         minimum_coverage: ${{ env.CODEBASE_MIN_THRESHOLD }}
         fail_below_threshold: true
+        only_changed_files: true
     - name: Evaluate Patch Coverage
       if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
       id: diff-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
+      CODEBASE_MIN_THRESHOLD: 90
+      PATCH_MIN_THRESHOLD: 80
     steps:
     - uses: actions/checkout@v4
       with:
@@ -80,23 +82,25 @@ jobs:
         retention-days: 14
         if-no-files-found: error
     - name: Evaluate Codebase Coverage
+      if: matrix.os == 'ubuntu-latest'
       uses: 5monkeys/cobertura-action@v14
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         path: coverage.xml
-        minimum_coverage: 90
+        minimum_coverage: ${{ env.CODEBASE_MIN_THRESHOLD }}
         fail_below_threshold: true
     - name: Evaluate Patch Coverage
-      if: github.event_name == 'pull_request'
+      if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
       id: diff-coverage
       uses: Affanmir/diff-cover-action@v2.1.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         coverage-files: coverage.xml
-        config-file: pyproject.toml
         create-annotations: true
+        compare-branch: "origin/main"
+        fail-under: ${{ env.PATCH_MIN_THRESHOLD }}
     - name: Generate coverage Badge
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: matrix.os == 'ubuntu-latest' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jaywcjlove/generated-badges@v1.1.0
       with:
         label: Coverage
@@ -104,7 +108,7 @@ jobs:
         status: ${{ steps.cov_outputs.outputs.percent }}
         color: ${{ steps.cov_outputs.outputs.color }}
     - name: Commit coverage badge
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: matrix.os == 'ubuntu-latest' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: stefanzweifel/git-auto-commit-action@v7.1.0
       with:
         commit_message: "[skip ci] Update coverage badge"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      checks: write
     strategy:
       matrix:
         python-version: [3.11]

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 *.py,cover
 .hypothesis/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SSEC-JHU <package_name>
 
 [![CI](https://github.com/ssec-jhu/base-template/actions/workflows/ci.yml/badge.svg)](https://github.com/ssec-jhu/base-template/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/ssec-jhu/base-template/branch/main/graph/badge.svg?token=0KPNKHRC2V)](https://codecov.io/gh/ssec-jhu/base-template)
+![Coverage](https://raw.githubusercontent.com/ssec-jhu/base-template/badges/coverage.svg)
 [![Security](https://github.com/ssec-jhu/base-template/actions/workflows/security.yml/badge.svg)](https://github.com/ssec-jhu/base-template/actions/workflows/security.yml)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14052740.svg)](https://doi.org/10.5281/zenodo.14052740)
 

--- a/coverage_writer.py
+++ b/coverage_writer.py
@@ -1,0 +1,15 @@
+import json
+import os
+
+if __name__ == "__main__":
+    # Read the coverage data from a file
+    with open('coverage.json', 'r') as f:
+        coverage_data = json.load(f)
+
+    total = int(coverage_data["totals"]["percent_covered_display"])
+
+    color = "green" if total >= 90 else "yellow" if total >= 80 else "red"
+
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+        f.write(f"percent={total}\n")
+        f.write(f"color={color}\n")

--- a/coverage_writer.py
+++ b/coverage_writer.py
@@ -1,3 +1,5 @@
+"""This script is used during the CI process to extract coverage information and generate a badge."""
+
 import json
 import os
 

--- a/coverage_writer.py
+++ b/coverage_writer.py
@@ -3,7 +3,7 @@ import os
 
 if __name__ == "__main__":
     # Read the coverage data from a file
-    with open('coverage.json', 'r') as f:
+    with open("coverage.json", "r") as f:
         coverage_data = json.load(f)
 
     total = int(coverage_data["totals"]["percent_covered_display"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,3 @@ convention = "google"
 docstring-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_docstring-quotes
 inline-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_inline-quotes
 multiline-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_multiline-quotes
-
-[tool.diff_cover]
-compare_branch = "origin/main"
-fail_under = "80"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,3 +115,7 @@ convention = "google"
 docstring-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_docstring-quotes
 inline-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_inline-quotes
 multiline-quotes = "double"  # https://docs.astral.sh/ruff/settings/#lint_flake8-quotes_multiline-quotes
+
+[tool.diff_cover]
+compare_branch = "origin/main"
+fail_under = "80"

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps =
     -r requirements/test.txt
     -r requirements/prd.txt
 commands=
-    pytest --cov=./ --cov-report=html:coverage.html --cov-report=xml:coverage.xml {posargs}
+    pytest --cov=./ --cov-report=json:coverage.json --cov-report=html:coverage.html --cov-report=xml:coverage.xml {posargs}
 
 [testenv:build-docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
This PR is a prototype for moving away from codecov :moneybag:  to GitHub actions :sunglasses: 

### What's changed

Codecov provides 4 functionalities. Below I list them along with what it is being replaced with:
1. Codebase level coverage :arrow_forward: `5monkeys/cobertura-action@v14`
    - parses `pytest-cov`'s coverage.xml 
    - will leave a comment regarding total coverage on PR
    - will fail if min_coverage is not met
    - minimum coverage is set to 90 (matches current config) via env variable at top of job
2. Patch level coverage :arrow_forward: `Affanmir/diff-cover-action@v2.1.0`
    - parses coverage.xml and git history to evaluate patch coverage
    - will fail if minimum coverage isn't met
    - minimum coverage is set to 80 (match current config) via env variable at top of job
3. Provides a README badge :arrow_forward: (manual parsing + jaywcjlove/generated-badges@v1.1.0 + stefanzweifel/git-auto-commit-action@v7.1.0)
    - This is hackiest part.
    - Coverage badge value and color are extracted and set using `coverage_writer.py`
    - The badge is generated using `jaywcjlove/generated-badges@v1.1.0`
    - The badge is committed to an orphan branch called `badges` using  `stefanzweifel/git-auto-commit-action@v7.1.0`
4. Coverage history lineage :arrow_forward: No longer supported
    - I don't think we really need this anyway
   
I am a little worried about having to have a `coverage_writer.py` file. It's not a lot so maybe it could be string and invoked via `python -c` in a bash action directly :shrug:. Also, part of this working is making the orphan branch which might be a bit much to setup. Though perhaps this could be done in `project_setup.py` rather than having a write up in the README.

### What's the setup process on a new repo

- Update the coverage token in the README.md
- create orphaned `badges` branch and push to remote (this might be doable in `project_setup.py`)
